### PR TITLE
added bootcamp list of topics

### DIFF
--- a/bootcamp/topics.md
+++ b/bootcamp/topics.md
@@ -1,0 +1,10 @@
+## Topics to cover during the bootcamp
+
+1. Introduction to the shell [from Software Carpentry](https://github.com/swcarpentry/shell-novice)   (2hrs)
+
+2. Introduction to git [from Software Carpentry](https://github.com/swcarpentry/git-novice)  (2hrs)
+
+3. Introduction to R [from Software Carpentry](http://swcarpentry.github.io/r-novice-gapminder) (2hrs)
+
+4. Introduction to statistics [lesson 1](http://physiology.med.cornell.edu/people/banfelder/qbio/lecture_notes/1.1_characterizing_a_distribution.pdf), [lesson 2](http://physiology.med.cornell.edu/people/banfelder/qbio/lecture_notes/1.2_pdfs_and_normal_distribution.pdf) from Jason Banfelder's course (2+ hrs)
+   - We'll need permission to use his material though...


### PR DESCRIPTION
added links and topics to cover during the bootcamp.  The links point to more or less complete lessons by either software carpentry, or the Banfelder notes.
